### PR TITLE
Allow passing BODY in GET request, defult to NO and via configurable …

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -82,9 +82,16 @@ export default class Request {
 		let method = init.method || input.method || 'GET';
 		method = method.toUpperCase();
 
+		let checkBodyllowedInGET = false;
+		// eslint-disable-next-line no-eq-null, eqeqeq
+		if ((init.overrideGetBodyCheck && init.overrideGetBodyCheck === true)
+			|| (isRequest(input) && input.overrideGetBodyCheck && input.overrideGetBodyCheck === true)){
+		  checkBodyllowedInGET = true;		
+		}
+
 		// eslint-disable-next-line no-eq-null, eqeqeq
 		if ((init.body != null || isRequest(input) && input.body !== null) &&
-			(method === 'GET' || method === 'HEAD')) {
+			(method === 'GET'  & checkBodyllowedInGET === false || method === 'HEAD')) {
 			throw new TypeError('Request with GET/HEAD method cannot have body');
 		}
 


### PR DESCRIPTION
…Parameter overrideGetBodyCheck in OPTIONS

Add configurable Parameter overrideGetBodyCheck, if set to true in OPTIONS, then it would bypass Error check for the Request "Body" in the GET request. It would allow the request if the parameter is set to true, otherwise, it would reject the GET requests with the BODY.